### PR TITLE
fix: migrate docker conda env to python 3.10

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -51,10 +51,8 @@ ENV PATH="/home/${USERNAME}/conda/bin:${PATH}"
 # Setup Bioconda channel configuration and install dependencies
 RUN conda config --add channels defaults && \
     conda config --add channels bioconda && \
-    conda config --add channels conda-forge && \
-    conda config --set channel_priority strict && \
     mamba install -y \
-        python=3.9 \
+        python=3.10 \
         gxx_linux-64 \
         bowtie>=1.2.3 \
         bowtie2>=2.3.5 \


### PR DESCRIPTION
This fix migrates the docker conda environment to python 3.10. This appears to be necessary due to some combination of changes in how mambaforge is handling trust certificates in the new dependency `truststore` and our particular environment setup.

This also removes some un-used conda configuration statements that were generating warning during the build.

Closes #56