### PR TITLE
Fixed missing rf-correlate output for single transcripts

### DIFF
--- a/rf-correlate
+++ b/rf-correlate
@@ -216,15 +216,18 @@ else {
         $table->row($_->[0], sprintf("%.3f", $_->[1]), sprintf("%.2e", $_->[2])) for (@results[0 .. $top - 1]);
         $table->print();
 
-        open(my $wh, ">", $output) or die "\n\n  [!] Error: Unable to write output file (" . $! . ")\n\n";
-        select((select($wh), $|=1)[0]);
-        print $wh "#Transcript\tCorrelation\tp-value\n";
-        print $wh join("\t", @$_) . "\n" for (@results);
-        close($wh);
 
     }
     else { print "\n\n  [!] Error: Correlation calculation failed for all transcripts"; }
 
+}
+
+if (@results){
+    open(my $wh, ">", $output) or die "\n\n  [!] Error: Unable to write output file (" . $! . ")\n\n";
+    select((select($wh), $|=1)[0]);
+    print $wh "#Transcript\tCorrelation\tp-value\n";
+    print $wh join("\t", @$_) . "\n" for (@results);
+    close($wh);
 }
 
 print "\n\n[+] Correlation statistics:\n" .


### PR DESCRIPTION
This pull request fixes an issue where no output file was generated when calculating the correlation for a single transcript.

Root cause:
The file creation logic was placed inside the else block of the `if ($singlefile && !$isRC)` condition.
As a result, when only one transcript was processed (i.e., $singlefile was true), the output file creation step was skipped.

Fix implemented:
Moved the file creation logic outside the conditional block so that the output file is created regardless of whether a single or multiple transcripts are processed.